### PR TITLE
ci: fix broken install, bump to Node 22/24, publish via OIDC

### DIFF
--- a/.github/workflows/cicd-next.yml
+++ b/.github/workflows/cicd-next.yml
@@ -10,7 +10,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        node: [20]
+        node: [22, 24]
     uses: ./.github/workflows/service_tests.yml
     with:
       node-version: ${{ matrix.node }}

--- a/.github/workflows/cicd-next.yml
+++ b/.github/workflows/cicd-next.yml
@@ -14,12 +14,15 @@ jobs:
     uses: ./.github/workflows/service_tests.yml
     with:
       node-version: ${{ matrix.node }}
-    secrets: inherit
 
   publish:
     needs: [tests]
     name: Publish @next
+    # Reusable workflows can only maintain or reduce the caller's permissions,
+    # never elevate them - so id-token must be granted here for OIDC to work.
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/service_publish.yml
     with:
       tag: next
-    secrets: inherit

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -10,7 +10,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        node: [20]
+        node: [22, 24]
     uses: ./.github/workflows/service_tests.yml
     with:
       node-version: ${{ matrix.node }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -14,12 +14,15 @@ jobs:
     uses: ./.github/workflows/service_tests.yml
     with:
       node-version: ${{ matrix.node }}
-    secrets: inherit
 
   publish:
     needs: [tests]
     name: Publish @latest
+    # Reusable workflows can only maintain or reduce the caller's permissions,
+    # never elevate them - so id-token must be granted here for OIDC to work.
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/service_publish.yml
     with:
       tag: latest
-    secrets: inherit

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "main"
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v6
         # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
         # with:
         #   config-name: my-config.yml

--- a/.github/workflows/service_publish.yml
+++ b/.github/workflows/service_publish.yml
@@ -1,4 +1,4 @@
-name: CI/CD (@next)
+name: Publish
 
 on:
   workflow_call:
@@ -13,55 +13,39 @@ jobs:
     name: Publish to NPM
     runs-on: ubuntu-latest
 
+    permissions:
+      # Required to mint the OIDC token npm exchanges for publish credentials.
+      # The package is configured as a Trusted Publisher on npmjs.org, pinned to
+      # ge-tracker/ge-tracker-api + this workflow file, so no NPM_TOKEN is needed.
+      id-token: write
+      contents: read
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 8
+      # Version comes from the "packageManager" field in package.json.
+      # Trusted publishing requires pnpm >= 11.
+      - uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: 'pnpm'
 
       # We may have to hoist dependencies to fix TS2742
       # https://github.com/microsoft/TypeScript/issues/47663#issuecomment-1519138189
       # https://github.com/microsoft/TypeScript/issues/47663
       - name: Install dependencies
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          mv .npmrc.ci .npmrc
-          echo 'node-linker=hoisted' >> .npmrc
+          echo 'node-linker=hoisted' > .npmrc
           pnpm install --frozen-lockfile
 
       - name: Publish to NPM (@${{ inputs.tag }})
         if: inputs.tag == 'latest'
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: pnpm publish --no-git-checks
 
       - name: Publish tagged to NPM (@${{ inputs.tag }})
         if: inputs.tag != 'latest'
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: pnpm publish --tag ${{ inputs.tag }} --no-git-checks
-#      - name: Publish to NPM (@latest)
-#        # Stop v5 releases being published to @latest
-#        if: ${{ !startsWith(github.ref_name, 'v5.') }}
-#        env:
-#          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-#        run: |
-#          mv .npmrc.ci .npmrc
-#          npm publish
-#
-#      - name: Publish to NPM (@v5)
-#        if: startsWith(github.ref_name, 'v5.')
-#        env:
-#          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-#        run: |
-#          mv .npmrc.ci .npmrc
-#          npm publish --tag v5

--- a/.github/workflows/service_tests.yml
+++ b/.github/workflows/service_tests.yml
@@ -7,7 +7,10 @@ on:
         required: false
         type: number
         description: 'Node.js version to use for the test run'
-        default: 20
+        default: 24
+
+permissions:
+  contents: read
 
 jobs:
   tests:
@@ -18,27 +21,24 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 8
+      # Version comes from the "packageManager" field in package.json
+      - uses: pnpm/action-setup@v6
 
       - name: Setup Node.js ${{ inputs.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ inputs.node-version }}
           cache: 'pnpm'
 
       - name: Install dependencies
         run: |
-          mv .npmrc.ci .npmrc
-          echo 'node-linker=hoisted' >> .npmrc
+          echo 'node-linker=hoisted' > .npmrc
           pnpm install --frozen-lockfile
 
-#      - name: Run ESLint
-#        run: pnpm run lint
+      - name: Typecheck
+        run: pnpm run typecheck
 
       - name: Run Tests (Node v${{ inputs.node-version }})
-        run: |
-          pnpm run test --ci
+        run: pnpm run test --ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,12 +12,19 @@ on:
       - '**.ts'
       - '**.tsx'
       - '**.json'
+      # Changes to CI or install config must validate themselves
+      - '.github/workflows/**'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
   pull_request:
     paths:
       - '**.js'
       - '**.ts'
       - '**.tsx'
       - '**.json'
+      - '.github/workflows/**'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
 
 permissions:
   contents: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,4 +30,3 @@ jobs:
     uses: ./.github/workflows/service_tests.yml
     with:
       node-version: ${{ matrix.node }}
-    secrets: inherit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,11 +19,14 @@ on:
       - '**.tsx'
       - '**.json'
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     strategy:
       matrix:
-        node: [20]
+        node: [22, 24]
     uses: ./.github/workflows/service_tests.yml
     with:
       node-version: ${{ matrix.node }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ yarn-error.log*
 .env
 .npm
 test-export.ts
+.npmrc

--- a/.npmrc.ci
+++ b/.npmrc.ci
@@ -1,5 +1,0 @@
-registry=https://registry.yarnpkg.com/
-@getracker:registry=https://registry.yarnpkg.com/
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}
-//registry.yarnpkg.com/:_authToken=${NPM_TOKEN}
-always-auth=true

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
   },
   "scripts": {
     "test": "jest --passWithNoTests",
+    "typecheck": "tsc --noEmit",
     "build": "pnpm run clean && tsup",
-    "clean": "rm -rf dist types",
+    "clean": "rm -rf dist",
     "dev": "tsup src/index.ts --watch --dts",
     "prettier": "prettier --write .",
     "prepublishOnly": "pnpm run build",
@@ -20,10 +21,13 @@
   },
   "files": [
     "dist",
-    "types",
     "jest"
   ],
   "type": "commonjs",
+  "packageManager": "pnpm@11.5.1",
+  "engines": {
+    "node": ">=22"
+  },
   "sideEffects": false,
   "source": "./src/index.ts",
   "exports": {
@@ -34,12 +38,12 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
-    "./types": "./types/index.d.ts",
+    "./types": "./dist/index.d.ts",
     "./jest/jest-mock": "./jest/jest-mock.ts"
   },
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
-  "types": "./types/index.d.ts",
+  "types": "./dist/index.d.ts",
   "dependencies": {
     "axios": "^1.6.2",
     "dayjs": "^1.11.10",
@@ -50,9 +54,9 @@
     "@babel/core": "^7.23.3",
     "@babel/preset-env": "^7.23.3",
     "@babel/preset-typescript": "^7.23.3",
-    "@tsconfig/node20": "^20.1.2",
+    "@tsconfig/node22": "^22.0.5",
     "@types/jest": "^29.5.10",
-    "@types/node": "^20.10.0",
+    "@types/node": "^22.20.1",
     "husky": "^8.0.3",
     "jest": "^29.7.0",
     "lint-staged": "^13.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,21 +30,21 @@ importers:
       '@babel/preset-typescript':
         specifier: ^7.23.3
         version: 7.29.7(@babel/core@7.29.7)
-      '@tsconfig/node20':
-        specifier: ^20.1.2
-        version: 20.1.9
+      '@tsconfig/node22':
+        specifier: ^22.0.5
+        version: 22.0.5
       '@types/jest':
         specifier: ^29.5.10
         version: 29.5.14
       '@types/node':
-        specifier: ^20.10.0
-        version: 20.19.43
+        specifier: ^22.20.1
+        version: 22.20.1
       husky:
         specifier: ^8.0.3
         version: 8.0.3
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.19.43)
+        version: 29.7.0(@types/node@22.20.1)
       lint-staged:
         specifier: ^13.3.0
         version: 13.3.0
@@ -1057,8 +1057,8 @@ packages:
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
 
-  '@tsconfig/node20@20.1.9':
-    resolution: {integrity: sha512-IjlTv1RsvnPtUcjTqtVsZExKVq+KQx4g5pCP5tI7rAs6Xesl2qFwSz/tPDBC4JajkL/MlezBu3gPUwqRHl+RIg==}
+  '@tsconfig/node22@22.0.5':
+    resolution: {integrity: sha512-hLf2ld+sYN/BtOJjHUWOk568dvjFQkHnLNa6zce25GIH+vxKfvTgm3qpaH6ToF5tu/NN0IH66s+Bb5wElHrLcw==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -1092,6 +1092,9 @@ packages:
 
   '@types/node@20.19.43':
     resolution: {integrity: sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==}
+
+  '@types/node@22.20.1':
+    resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -3582,7 +3585,7 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@tsconfig/node20@20.1.9': {}
+  '@tsconfig/node22@22.0.5': {}
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -3627,6 +3630,10 @@ snapshots:
       pretty-format: 29.7.0
 
   '@types/node@20.19.43':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/node@22.20.1':
     dependencies:
       undici-types: 6.21.0
 
@@ -3887,13 +3894,13 @@ snapshots:
     dependencies:
       browserslist: 4.28.7
 
-  create-jest@29.7.0(@types/node@20.19.43):
+  create-jest@29.7.0(@types/node@22.20.1):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.19.43)
+      jest-config: 29.7.0(@types/node@22.20.1)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -4285,16 +4292,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.19.43):
+  jest-cli@29.7.0(@types/node@22.20.1):
     dependencies:
       '@jest/core': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.19.43)
+      create-jest: 29.7.0(@types/node@22.20.1)
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@20.19.43)
+      jest-config: 29.7.0(@types/node@22.20.1)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.3
@@ -4330,6 +4337,36 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.19.43
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@29.7.0(@types/node@22.20.1):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.7)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.20.1
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -4549,12 +4586,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@20.19.43):
+  jest@29.7.0(@types/node@22.20.1):
     dependencies:
       '@jest/core': 29.7.0
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@20.19.43)
+      jest-cli: 29.7.0(@types/node@22.20.1)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node20/tsconfig.json",
+  "extends": "@tsconfig/node22/tsconfig.json",
   "compilerOptions": {
     "module": "es2022",
     "moduleResolution": "bundler",
@@ -11,5 +11,6 @@
     "sourceMap": true,
     "typeRoots": ["./node_modules/@types"],
     "types": ["node", "jest"]
-  }
+  },
+  "include": ["src"]
 }


### PR DESCRIPTION
## Why

CI has been red since `9ad1735`. It was never a test failure — **every run died at `pnpm install`, before tests ran**:

```
ERR_PNPM_INVALID_WORKSPACE_CONFIGURATION  packages field missing or empty
```

`pnpm-workspace.yaml` was added with only an `allowBuilds:` key. pnpm 8 (pinned in CI) rejects a workspace file with no `packages:` field. Local pnpm 11 accepts it, so it only broke on push.

Note: there are currently **no test files** in the repo, so `jest --passWithNoTests` exits 0 locally. Nothing was failing locally.

## Install chain

- Pin `packageManager: pnpm@11.5.1`. The lockfile is v9, so pnpm 8 would have failed `--frozen-lockfile` immediately after the workspace error regardless.
- Node matrix `20` → `22, 24`; `checkout@v7`, `setup-node@v7`, `action-setup@v6`. Clears the Node 20 runner deprecation warnings.
- `@tsconfig/node20` → `@tsconfig/node22`, `@types/node ^22`, `engines: node >=22`.

## OIDC publishing

Completes the work started on the (now deleted) `oidc` branch and wires it to the npmjs.org trusted-publisher config for `service_publish.yml`.

- `id-token: write` on the reusable workflow **and on both caller jobs**. The `oidc` branch only had the former. Per [GitHub docs](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows), reusable-workflow permissions "can only be maintained or reduced—not elevated", and `id-token` is never granted by default — so caller-side grants are required or the first release fails.
- The `oidc` branch also kept `version: 8`. Verified against the shipped binaries that **pnpm 10.34.5 has no OIDC support**; only 11.x implements the `ACTIONS_ID_TOKEN_REQUEST_URL` exchange.
- Deleted `.npmrc.ci`: it injected an empty `${NPM_TOKEN}` and pointed at the legacy `registry.yarnpkg.com` mirror, which trusted publishing can't use. `pnpm publish --dry-run` now resolves to `registry.npmjs.org`.
- Dropped 5 dead `secrets: inherit` — no workflow consumes a secret anymore.

## Incidental fixes

**Path filters excluded CI config.** `tests.yml` only matched `**.js/.ts/.tsx/.json`, so `.github/**` and `pnpm-*.yaml` changes never triggered CI — which is precisely how the broken workspace file reached `main` untested. Added those paths; confirmed by watching a workflow-only commit trigger a run.

**Dangling type entrypoints.** `types/` is never emitted by the build, but `package.json` had `"types": "./types/index.d.ts"`, a `./types` export subpath, and `types` in `files`. Consumers on `moduleResolution: node` resolved to nothing. Repointed at `dist/`; verified with `pnpm pack`.

**`tsc --noEmit` was broken.** `rootDir: ./src` conflicted with the default include glob (TS6059). Scoped `include` to `src` and added a `typecheck` script, now run in CI.

## Verification

- Tests green on Node 22 and 24.
- Locally reproduced the full CI path in a clean checkout: hoisted `--frozen-lockfile` install → typecheck → test → build.
- `pnpm pack` contents match every path the manifest references.

**Not verified:** the OIDC publish itself only runs on `v*` tags, so it can't be exercised until the next release. Everything up to the publish step is verified.

## Follow-ups

- `NPM_TOKEN` repo secret is now unused and can be deleted.
- Repo still has no tests.
- Dependency majors left alone as out of scope: jest 30, TS 7, babel 8, husky 9, lint-staged 17, tsup 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
